### PR TITLE
Add OpenShift Compatibility to Data Flywheel Helm Chart

### DIFF
--- a/deploy/helm/data-flywheel/templates/_helpers.tpl
+++ b/deploy/helm/data-flywheel/templates/_helpers.tpl
@@ -60,3 +60,40 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate pod-level security context for OpenShift
+*/}}
+{{- define "data-flywheel.podSecurityContext" -}}
+{{- if .Values.openshift.enabled }}
+runAsNonRoot: true
+seccompProfile:
+  type: {{ .Values.openshift.securityContext.pod.seccompProfile.type }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate container-level security context for OpenShift
+*/}}
+{{- define "data-flywheel.containerSecurityContext" -}}
+{{- if .Values.openshift.enabled }}
+allowPrivilegeEscalation: {{ .Values.openshift.securityContext.container.allowPrivilegeEscalation }}
+runAsNonRoot: {{ .Values.openshift.securityContext.container.runAsNonRoot }}
+capabilities:
+  drop:
+    {{- range .Values.openshift.securityContext.container.capabilities.drop }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine service type based on OpenShift mode
+*/}}
+{{- define "data-flywheel.serviceType" -}}
+{{- if .Values.openshift.enabled -}}
+ClusterIP
+{{- else -}}
+NodePort
+{{- end -}}
+{{- end }}

--- a/deploy/helm/data-flywheel/templates/api-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/api-deployment.yaml
@@ -20,18 +20,37 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       automountServiceAccountToken: false
       initContainers:
+        {{- if .Values.openshift.enabled }}
+        - name: create-data-folder-for-dataset
+          image: {{ .Values.openshift.initContainer.image }}
+          command: ['sh', '-c', 'mkdir -p /data']
+          volumeMounts:
+            - name: data-volume
+              mountPath: /data
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+        {{- else }}
         - name: create-data-folder-for-dataset
           image: busybox:1.28
           command: ['sh', '-c', 'mkdir -p /data && chmod 755 /data']
           volumeMounts:
             - name: data-volume
               mountPath: /data
+        {{- end }}
       containers:
         - name: api
           image: "{{ .Values.foundationalFlywheelServer.image.repository }}:{{ .Values.foundationalFlywheelServer.image.tag }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.api.resources | nindent 12 }}
           ports:
@@ -49,6 +68,14 @@ spec:
               value: {{ .Values.profile.mlflow.COMPOSE_PROFILES | quote }}
             - name: ES_COLLECTION_NAME
               value: {{ .Values.foundationalFlywheelServer.deployments.api.env.ES_COLLECTION_NAME | quote }}
+            {{- if .Values.openshift.enabled }}
+            - name: HOME
+              value: "/tmp"
+            - name: UV_CACHE_DIR
+              value: "/tmp/.uv-cache"
+            - name: UV_PROJECT_ENVIRONMENT
+              value: "/tmp/.venv"
+            {{- end }}
             - name: NVIDIA_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/data-flywheel/templates/api-route.yaml
+++ b/deploy/helm/data-flywheel/templates/api-route.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.openshift.enabled .Values.openshift.routes.enabled .Values.openshift.routes.api.enabled .Values.foundationalFlywheelServer.deployments.api.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.foundationalFlywheelServer.deployments.api.fullnameOverride }}-route
+  labels:
+    app: {{ .Values.foundationalFlywheelServer.deployments.api.fullnameOverride }}-deployment
+spec:
+  {{- if .Values.openshift.routes.api.host }}
+  host: {{ .Values.openshift.routes.api.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ .Values.foundationalFlywheelServer.deployments.api.fullnameOverride }}-service
+    weight: 100
+  port:
+    targetPort: {{ .Values.foundationalFlywheelServer.deployments.api.service.port }}
+  {{- if .Values.openshift.routes.api.tls.enabled }}
+  tls:
+    termination: {{ .Values.openshift.routes.api.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.routes.api.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/data-flywheel/templates/api-service.yaml
+++ b/deploy/helm/data-flywheel/templates/api-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     app: {{ .Values.foundationalFlywheelServer.deployments.api.fullnameOverride }}-deployment
-  type: {{ .Values.foundationalFlywheelServer.deployments.api.service.type }}
+  type: {{ include "data-flywheel.serviceType" . }}
   ports:
     - port: {{ .Values.foundationalFlywheelServer.deployments.api.service.port }}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/celeryParentWorker-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/celeryParentWorker-deployment.yaml
@@ -19,10 +19,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-parent-worker
           image: "{{ .Values.foundationalFlywheelServer.image.repository }}:{{ .Values.foundationalFlywheelServer.image.tag }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.celeryParentWorker.resources | nindent 12 }}
           ports:
@@ -65,6 +73,14 @@ spec:
                   name: {{ .Values.nvidiaApiSecret.name | default "nvidia-api" }}
                   key: {{ .Values.nvidiaApiSecret.key | default "NVIDIA_API_KEY" }}
                   {{ end }}
+            {{- if .Values.openshift.enabled }}
+            - name: HOME
+              value: "/tmp"
+            - name: UV_CACHE_DIR
+              value: "/tmp/.uv-cache"
+            - name: UV_PROJECT_ENVIRONMENT
+              value: "/tmp/.venv"
+            {{- end }}
           command:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.celeryParentWorker.command | nindent 12 }}
           volumeMounts:

--- a/deploy/helm/data-flywheel/templates/celeryWorker-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/celeryWorker-deployment.yaml
@@ -21,10 +21,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker
           image: "{{ .Values.foundationalFlywheelServer.image.repository }}:{{ .Values.foundationalFlywheelServer.image.tag }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.celeryWorker.resources | nindent 12 }}
           ports:
@@ -67,6 +75,14 @@ spec:
                   name: {{ .Values.nvidiaApiSecret.name | default "nvidia-api" }}
                   key: {{ .Values.nvidiaApiSecret.key | default "NVIDIA_API_KEY" }}
                   {{ end }}
+            {{- if .Values.openshift.enabled }}
+            - name: HOME
+              value: "/tmp"
+            - name: UV_CACHE_DIR
+              value: "/tmp/.uv-cache"
+            - name: UV_PROJECT_ENVIRONMENT
+              value: "/tmp/.venv"
+            {{- end }}
           command:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.celeryWorker.command | nindent 12 }}
           volumeMounts:

--- a/deploy/helm/data-flywheel/templates/elasticsearch-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/elasticsearch-deployment.yaml
@@ -17,10 +17,18 @@ spec:
         app: {{ .Values.elasticsearch.fullnameOverride }}-deployment
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: elasticsearch
           image: "{{ .Values.elasticsearch.image.repository }}:{{ .Values.elasticsearch.image.tag }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.elasticsearch.resources | nindent 12 }}
           ports:

--- a/deploy/helm/data-flywheel/templates/elasticsearch-service.yaml
+++ b/deploy/helm/data-flywheel/templates/elasticsearch-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     app: {{ .Values.elasticsearch.fullnameOverride }}-deployment
-  type: {{ .Values.elasticsearch.service.type }}
+  type: {{ include "data-flywheel.serviceType" . }}
   ports:
     - port: {{ .Values.elasticsearch.service.port }}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/flower-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/flower-deployment.yaml
@@ -21,10 +21,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       automountServiceAccountToken: false
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: flower
           image: "{{ .Values.foundationalFlywheelServer.image.repository }}:{{ .Values.foundationalFlywheelServer.image.tag }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.flower.resources | nindent 12 }}
           ports:
@@ -65,6 +73,14 @@ spec:
                   name: {{ .Values.nvidiaApiSecret.name | default "nvidia-api" }}
                   key: {{ .Values.nvidiaApiSecret.key | default "NVIDIA_API_KEY" }}
                   {{ end }}
+            {{- if .Values.openshift.enabled }}
+            - name: HOME
+              value: "/tmp"
+            - name: UV_CACHE_DIR
+              value: "/tmp/.uv-cache"
+            - name: UV_PROJECT_ENVIRONMENT
+              value: "/tmp/.venv"
+            {{- end }}
           command:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.flower.command | nindent 12 }}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/flower-route.yaml
+++ b/deploy/helm/data-flywheel/templates/flower-route.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.openshift.enabled .Values.openshift.routes.enabled .Values.openshift.routes.flower.enabled (not .Values.profile.production.enabled) }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.foundationalFlywheelServer.deployments.flower.fullnameOverride }}-route
+  labels:
+    app: {{ .Values.foundationalFlywheelServer.deployments.flower.fullnameOverride }}-deployment
+spec:
+  {{- if .Values.openshift.routes.flower.host }}
+  host: {{ .Values.openshift.routes.flower.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ .Values.foundationalFlywheelServer.deployments.flower.fullnameOverride }}-service
+    weight: 100
+  port:
+    targetPort: {{ .Values.foundationalFlywheelServer.deployments.flower.service.port }}
+  {{- if .Values.openshift.routes.flower.tls.enabled }}
+  tls:
+    termination: {{ .Values.openshift.routes.flower.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.routes.flower.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/data-flywheel/templates/flower-service.yaml
+++ b/deploy/helm/data-flywheel/templates/flower-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     app: {{ .Values.foundationalFlywheelServer.deployments.flower.fullnameOverride }}-deployment
-  type: {{ .Values.foundationalFlywheelServer.deployments.flower.service.type }}
+  type: {{ include "data-flywheel.serviceType" . }}
   ports:
     - port: {{ .Values.foundationalFlywheelServer.deployments.flower.service.port }}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/kibana-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/kibana-deployment.yaml
@@ -17,10 +17,18 @@ spec:
         app: {{ .Values.kibana.fullnameOverride }}-deployment
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: kibana
           image: "{{ .Values.kibana.image.repository }}:{{ .Values.kibana.image.tag }}"
           imagePullPolicy: {{ .Values.kibana.image.pullPolicy }}
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.kibana.resources | nindent 12 }}
           env:

--- a/deploy/helm/data-flywheel/templates/kibana-route.yaml
+++ b/deploy/helm/data-flywheel/templates/kibana-route.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.openshift.enabled .Values.openshift.routes.enabled .Values.openshift.routes.kibana.enabled (not .Values.profile.production.enabled) }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.kibana.fullnameOverride }}-route
+  labels:
+    app: {{ .Values.kibana.fullnameOverride }}-deployment
+spec:
+  {{- if .Values.openshift.routes.kibana.host }}
+  host: {{ .Values.openshift.routes.kibana.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ .Values.kibana.fullnameOverride }}-service
+    weight: 100
+  port:
+    targetPort: {{ .Values.kibana.service.port }}
+  {{- if .Values.openshift.routes.kibana.tls.enabled }}
+  tls:
+    termination: {{ .Values.openshift.routes.kibana.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.routes.kibana.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/data-flywheel/templates/kibana-service.yaml
+++ b/deploy/helm/data-flywheel/templates/kibana-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     app: {{ .Values.kibana.fullnameOverride }}-deployment
-  type: {{ .Values.kibana.service.type }}
+  type: {{ include "data-flywheel.serviceType" . }}
   ports:
     - name: http
       port: {{ .Values.kibana.service.port }}

--- a/deploy/helm/data-flywheel/templates/mlflow-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/mlflow-deployment.yaml
@@ -20,18 +20,37 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
       automountServiceAccountToken: false
       initContainers:
+        {{- if .Values.openshift.enabled }}
+        - name: create-mlflow-data-folder
+          image: {{ .Values.openshift.initContainer.image }}
+          command: ['sh', '-c', 'mkdir -p /mlruns']
+          volumeMounts:
+            - name: mlflow-data-volume
+              mountPath: /mlruns
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+        {{- else }}
         - name: create-mlflow-data-folder
           image: busybox:1.28
           command: ['sh', '-c', 'mkdir -p /mlruns && chmod 755 /mlruns']
           volumeMounts:
             - name: mlflow-data-volume
               mountPath: /mlruns
+        {{- end }}
       containers:
         - name: mlflow
           image: "{{ .Values.foundationalFlywheelServer.deployments.mlflow.image }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.foundationalFlywheelServer.deployments.mlflow.resources | nindent 12 }}
           ports:

--- a/deploy/helm/data-flywheel/templates/mlflow-route.yaml
+++ b/deploy/helm/data-flywheel/templates/mlflow-route.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.openshift.enabled .Values.openshift.routes.enabled .Values.openshift.routes.mlflow.enabled (eq .Values.profile.mlflow.COMPOSE_PROFILES "mlflow") }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.foundationalFlywheelServer.deployments.mlflow.fullnameOverride }}-route
+  labels:
+    app: {{ .Values.foundationalFlywheelServer.deployments.mlflow.fullnameOverride }}-deployment
+spec:
+  {{- if .Values.openshift.routes.mlflow.host }}
+  host: {{ .Values.openshift.routes.mlflow.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ .Values.foundationalFlywheelServer.deployments.mlflow.fullnameOverride }}-service
+    weight: 100
+  port:
+    targetPort: {{ .Values.foundationalFlywheelServer.deployments.mlflow.service.port }}
+  {{- if .Values.openshift.routes.mlflow.tls.enabled }}
+  tls:
+    termination: {{ .Values.openshift.routes.mlflow.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.routes.mlflow.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/data-flywheel/templates/mlflow-service.yaml
+++ b/deploy/helm/data-flywheel/templates/mlflow-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     app: {{ .Values.foundationalFlywheelServer.deployments.mlflow.fullnameOverride }}-deployment
-  type: {{ .Values.foundationalFlywheelServer.deployments.mlflow.service.type }}
+  type: {{ include "data-flywheel.serviceType" . }}
   ports:
     - port: {{ .Values.foundationalFlywheelServer.deployments.mlflow.service.port }}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/mongodb-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/mongodb-deployment.yaml
@@ -17,12 +17,44 @@ spec:
         app: {{ .Values.mongodb.fullnameOverride }}-deployment
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.openshift.enabled }}
+        - name: create-mongodb-data-folder
+          image: {{ .Values.openshift.initContainer.image }}
+          command: ['sh', '-c', 'mkdir -p /data/db']
+          volumeMounts:
+            - name: mongodb-data-volume
+              mountPath: /data/db
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+        {{- else }}
+        - name: create-mongodb-data-folder
+          image: busybox:1.28
+          command: ['sh', '-c', 'mkdir -p /data/db && chmod 755 /data/db']
+          volumeMounts:
+            - name: mongodb-data-volume
+              mountPath: /data/db
+        {{- end }}
       containers:
         - name: mongodb
           image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.mongodb.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.mongodb.service.port }}
+          volumeMounts:
+            - name: mongodb-data-volume
+              mountPath: /data/db
+      volumes:
+        - name: mongodb-data-volume
+          emptyDir: {}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/mongodb-service.yaml
+++ b/deploy/helm/data-flywheel/templates/mongodb-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     app: {{ .Values.mongodb.fullnameOverride }}-deployment
-  type: {{ .Values.mongodb.service.type }}
+  type: {{ include "data-flywheel.serviceType" . }}
   ports:
     - port: {{ .Values.mongodb.service.port }}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/redis-deployment.yaml
+++ b/deploy/helm/data-flywheel/templates/redis-deployment.yaml
@@ -17,12 +17,44 @@ spec:
         app: {{ .Values.redis.fullnameOverride }}-deployment
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.openshift.enabled }}
+      securityContext:
+        {{- include "data-flywheel.podSecurityContext" . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.openshift.enabled }}
+        - name: create-redis-data-folder
+          image: {{ .Values.openshift.initContainer.image }}
+          command: ['sh', '-c', 'mkdir -p /data']
+          volumeMounts:
+            - name: redis-data-volume
+              mountPath: /data
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+        {{- else }}
+        - name: create-redis-data-folder
+          image: busybox:1.28
+          command: ['sh', '-c', 'mkdir -p /data && chmod 755 /data']
+          volumeMounts:
+            - name: redis-data-volume
+              mountPath: /data
+        {{- end }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: Always
+          {{- if .Values.openshift.enabled }}
+          securityContext:
+            {{- include "data-flywheel.containerSecurityContext" . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.redis.service.port }}
+          volumeMounts:
+            - name: redis-data-volume
+              mountPath: /data
+      volumes:
+        - name: redis-data-volume
+          emptyDir: {}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/redis-service.yaml
+++ b/deploy/helm/data-flywheel/templates/redis-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   selector:
     app: {{ .Values.redis.fullnameOverride }}-deployment
-  type: {{ .Values.redis.service.type }}
+  type: {{ include "data-flywheel.serviceType" . }}
   ports:
     - port: {{ .Values.redis.service.port }}
 {{- end }}

--- a/deploy/helm/data-flywheel/templates/secrets.yaml
+++ b/deploy/helm/data-flywheel/templates/secrets.yaml
@@ -17,6 +17,7 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if .Values.secrets.ngcApiKey }}
 ---
 apiVersion: v1
 kind: Secret
@@ -29,8 +30,10 @@ metadata:
     "helm.sh/resource-policy": delete
 type: Opaque
 data:
-  NGC_API_KEY: {{ if .Values.secrets.ngcApiKey }}{{ .Values.secrets.ngcApiKey | b64enc }}{{ else }}{{ "" | b64enc }}{{ end }}
+  NGC_API_KEY: {{ .Values.secrets.ngcApiKey | b64enc }}
+{{- end }}
 
+{{- if .Values.secrets.nvidiaApiKey }}
 ---
 apiVersion: v1
 kind: Secret
@@ -43,8 +46,10 @@ metadata:
     "helm.sh/resource-policy": delete
 type: Opaque
 data:
-  NVIDIA_API_KEY: {{ if .Values.secrets.nvidiaApiKey }}{{ .Values.secrets.nvidiaApiKey | b64enc }}{{ else }}{{ "" | b64enc }}{{ end }}
+  NVIDIA_API_KEY: {{ .Values.secrets.nvidiaApiKey | b64enc }}
+{{- end }}
 
+{{- if .Values.secrets.hfToken }}
 ---
 apiVersion: v1
 kind: Secret
@@ -57,7 +62,8 @@ metadata:
     "helm.sh/resource-policy": delete
 type: Opaque
 data:
-  HF_TOKEN: {{ if .Values.secrets.hfToken }}{{ .Values.secrets.hfToken | b64enc }}{{ else }}{{ "" | b64enc }}{{ end }}
+  HF_TOKEN: {{ .Values.secrets.hfToken | b64enc }}
+{{- end }}
 
 {{- if .Values.secrets.llmJudgeApiKey }}
 ---

--- a/deploy/helm/data-flywheel/values.yaml
+++ b/deploy/helm/data-flywheel/values.yaml
@@ -4,6 +4,67 @@
 
 namespace: "nv-nvidia-blueprint-data-flywheel"
 
+# OpenShift-specific configuration
+openshift:
+  enabled: false  # Set to true to enable OpenShift-compatible deployment
+
+  # Security Context configuration for OpenShift restricted SCC
+  securityContext:
+    # Pod-level security context
+    pod:
+      runAsNonRoot: true
+      # Note: fsGroup is automatically assigned by OpenShift from namespace UID/GID range
+      # Do not set fsGroup explicitly as it conflicts with restricted-v2 SCC
+      seccompProfile:
+        type: RuntimeDefault
+
+    # Container-level security context
+    container:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
+
+  # Route configuration for external access
+  routes:
+    enabled: true
+    api:
+      enabled: true
+      host: ""  # Auto-generated if empty
+      tls:
+        enabled: true
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    mlflow:
+      enabled: true
+      host: ""
+      tls:
+        enabled: true
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    kibana:
+      enabled: true
+      host: ""
+      tls:
+        enabled: true
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+    flower:
+      enabled: true
+      host: ""
+      tls:
+        enabled: true
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+
+  # Storage class override for OpenShift
+  storageClass: "gp3-csi"
+
+  # Init container image for OpenShift compatibility
+  initContainer:
+    image: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
+
 # Deployment profile settings
 # - For production profile, kibana and Data Flywheel flower server are disabled
 #   For non-production profiles, kibana and Data Flywheel flower server are enabled

--- a/docs/openshift.md
+++ b/docs/openshift.md
@@ -1,0 +1,647 @@
+# NVIDIA Data Flywheel Blueprint on OpenShift
+
+This guide provides instructions for deploying the NVIDIA Data Flywheel Blueprint on Red Hat OpenShift Container Platform (OCP), including integration with NVIDIA NeMo Microservices.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Architecture](#architecture)
+- [Installation](#installation)
+  - [Step 1: Deploy NeMo Microservices](#step-1-deploy-nemo-microservices)
+  - [Step 2: Deploy Data Flywheel](#step-2-deploy-data-flywheel)
+- [Configuration](#configuration)
+- [Verification](#verification)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The Data Flywheel Blueprint on OpenShift provides:
+- **OpenShift-native deployment** with Security Context Constraints (SCC) compliance
+- **Route-based external access** using OpenShift Routes with TLS
+- **Shared secret management** with NeMo Microservices
+- **Storage class flexibility** for OpenShift-specific storage backends
+- **Restricted security contexts** compliant with OpenShift's security policies
+
+## Prerequisites
+
+### Cluster Requirements
+- Red Hat OpenShift Container Platform 4.x
+- GPU-enabled worker nodes (for model training and inference)
+- Cluster administrator access for creating namespaces and RBAC resources
+- Available storage class for persistent volumes (e.g., `gp3-csi`)
+
+### Required Tools
+- `oc` CLI configured and authenticated to your cluster
+- `helm` 3.x installed locally
+- `git` for cloning repositories
+
+### API Keys
+You will need the following API keys:
+
+| Key | Purpose | How to Obtain |
+|-----|---------|---------------|
+| **NGC_API_KEY** | Pull NVIDIA container images and download models | [Generate at NGC](https://ngc.nvidia.com/setup/api-key) |
+| **NVIDIA_API_KEY** | Access NVIDIA API Catalog for remote inference | [Generate at NVIDIA API Catalog](https://build.nvidia.com/explore/discover) |
+| **HF_TOKEN** | Access Hugging Face models and datasets | [Generate at Hugging Face](https://huggingface.co/settings/tokens) |
+
+### Storage Requirements
+
+The deployment requires persistent storage across multiple components:
+
+| Component | Purpose | Default Size | Adjustable |
+|-----------|---------|--------------|------------|
+| NeMo Customizer (model cache) | Base model storage | 100 Gi | Yes |
+| NeMo Customizer (workspace) | Training workspace | 50 Gi | Yes |
+| Vector DB (Milvus) | Embedding vectors | 100 Gi | Yes |
+| NIMCache | Model inference cache | 100 Gi | Yes |
+| PostgreSQL databases | Multiple DB instances | ~10 Gi total | Yes |
+| Elasticsearch | Logging and data | Ephemeral | Via resources |
+| MongoDB | Metadata storage | Ephemeral | Via resources |
+| Redis | Task queueing | Ephemeral | Via resources |
+
+**Total estimated storage:** ~360 Gi for a minimal deployment with persistent storage.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    OpenShift Routes                     │
+│  (TLS Edge Termination - External Access)               │
+│  • df-api-route      → Data Flywheel API                │
+│  • df-mlflow-route   → MLflow UI                        │
+│  • df-kibana-route   → Kibana UI                        │
+│  • df-flower-route   → Celery Flower UI                 │
+└─────────────────────────────────────────────────────────┘
+                            │
+┌─────────────────────────────────────────────────────────┐
+│              Data Flywheel Services                     │
+│  • df-api            → FastAPI REST API                 │
+│  • df-celery-worker  → Task execution workers           │
+│  • df-celery-parent  → Task orchestration               │
+│  • df-mlflow         → Experiment tracking              │
+│  • df-flower         → Task monitoring                  │
+└─────────────────────────────────────────────────────────┘
+                            │
+┌─────────────────────────────────────────────────────────┐
+│           Infrastructure Services                       │
+│  • df-elasticsearch  → Logging and data storage         │
+│  • df-mongodb        → Metadata storage                 │
+│  • df-redis          → Task queue                       │
+└─────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────┐
+│         NeMo Microservices Platform                     │
+│  • nemo-gateway      → API Gateway                      │
+│  • nemodatastore     → Data management                  │
+│  • nemocustomizer    → Model fine-tuning                │
+│  • nemoevaluator     → Model evaluation                 │
+│  • nemoguardrails    → Safety guardrails                │
+│  • NIM services      → Model inference                  │
+└─────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────┐
+│                Shared Kubernetes Secrets                │
+│  • nvcrimagepullsecret → NGC container registry auth    │
+│  • ngc-api             → NGC API key                    │
+│  • nvidia-api          → NVIDIA API key                 │
+│  • hf-secret           → Hugging Face token             │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Installation
+
+### Step 1: Deploy NeMo Microservices
+
+The Data Flywheel Blueprint depends on NeMo Microservices for model training, evaluation, and inference capabilities.
+
+**📖 Follow the complete installation guide:**
+**[NeMo Microservices on OpenShift Installation Guide](https://github.com/RHEcosystemAppEng/NeMo-Microservices)**
+
+This guide includes OpenShift-specific configuration, Security Context Constraints, GPU operator setup, secret creation, and verification steps.
+
+**Important:** The secrets created during NeMo installation (`nvcrimagepullsecret`, `ngc-api`, `nvidia-api`, `hf-secret`) are shared with Data Flywheel. Do not delete or modify these secrets.
+
+### Step 2: Deploy Data Flywheel
+
+Once NeMo Microservices is running, deploy the Data Flywheel Blueprint.
+
+#### 2.1 Clone the Repository
+
+```bash
+git clone https://github.com/NVIDIA-AI-Blueprints/nvidia-data-flywheel.git
+cd nvidia-data-flywheel
+```
+
+#### 2.2 Install Data Flywheel using Helm
+
+Since NeMo Microservices has already created the required secrets, you can deploy Data Flywheel without re-creating them:
+
+```bash
+# Set your namespace (same as NeMo installation)
+export NAMESPACE="data-flywheel"
+
+# Install Data Flywheel
+helm install data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  --set openshift.enabled=true \
+  --set namespace=$NAMESPACE \
+  --set foundationalFlywheelServer.config.nmp_config.nemo_base_url="http://nemo-gateway" \
+  --set foundationalFlywheelServer.config.nmp_config.nmp_namespace="$NAMESPACE" \
+  --set nemo-microservices-helm-chart.enabled=false \
+  --set mongodb.image.repository="docker.io/mongo" \
+  --skip-crds
+```
+
+**Command Breakdown:**
+- `--set openshift.enabled=true`: Enables OpenShift-specific features (Routes, SCCs, security contexts)
+- `--set namespace=$NAMESPACE`: Sets the deployment namespace
+- `--set foundationalFlywheelServer.config.nmp_config.nemo_base_url="http://nemo-gateway"`: Points to NeMo gateway service
+- `--set foundationalFlywheelServer.config.nmp_config.nmp_namespace="$NAMESPACE"`: Tells Data Flywheel where NeMo resources are located
+- `--set nemo-microservices-helm-chart.enabled=false`: Disables NeMo subchart (already installed separately)
+- `--set mongodb.image.repository="docker.io/mongo"`: Uses Docker Hub MongoDB image (OpenShift compatible)
+- `--skip-crds`: Skips CRD installation (volcano CRDs already installed by NeMo)
+
+#### 2.3 Alternative: Using a Values File
+
+For production deployments, you can create a custom values file:
+
+```bash
+# Create a custom values file
+cat > values-openshift.yaml <<EOF
+# OpenShift configuration
+openshift:
+  enabled: true
+  storageClass: "gp3-csi"  # Adjust to your cluster's storage class
+
+# Namespace configuration
+namespace: "$NAMESPACE"
+
+# Shared secrets (already created by NeMo installation)
+# Leave empty to use existing secrets
+secrets:
+  ngcApiKey: ""
+  nvidiaApiKey: ""
+  hfToken: ""
+  llmJudgeApiKey: ""
+  embApiKey: ""
+
+# NeMo Microservices integration
+foundationalFlywheelServer:
+  config:
+    nmp_config:
+      nemo_base_url: "http://nemo-gateway"
+      nim_base_url: "http://nemo-gateway"
+      datastore_base_url: "http://nemodatastore-sample:8000"
+      nmp_namespace: "$NAMESPACE"
+
+# Disable NeMo subchart (already installed)
+nemo-microservices-helm-chart:
+  enabled: false
+
+# Use Docker Hub for MongoDB (OpenShift compatible)
+mongodb:
+  image:
+    repository: "docker.io/mongo"
+EOF
+
+# Install using the values file
+helm install data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  -f values-openshift.yaml \
+  --skip-crds
+```
+
+## Configuration
+
+### OpenShift-Specific Settings
+
+The Helm chart includes several OpenShift-specific configurations enabled via `openshift.enabled=true`:
+
+#### Security Context Constraints (SCC)
+
+All deployments use the `restricted-v2` SCC with:
+- **Pod-level security:**
+  - `runAsNonRoot: true`
+  - `seccompProfile.type: RuntimeDefault`
+  - UID/GID automatically assigned by OpenShift from namespace range
+
+- **Container-level security:**
+  - `allowPrivilegeEscalation: false`
+  - `runAsNonRoot: true`
+  - `capabilities.drop: [ALL]`
+
+#### OpenShift Routes
+
+External access is provided via OpenShift Routes with TLS edge termination:
+
+| Route Name | Service | Default Port | Purpose |
+|------------|---------|--------------|---------|
+| `df-api-route` | df-api-service | 8000 | Data Flywheel REST API |
+| `df-mlflow-route` | df-mlflow-service | 5000 | MLflow experiment tracking UI |
+| `df-kibana-route` | df-kibana-service | 5601 | Kibana logging visualization |
+| `df-flower-route` | df-flower-service | 5555 | Celery task monitoring |
+
+Access routes with:
+```bash
+# Get route URLs
+oc get routes -n $NAMESPACE
+
+# Example: Access API
+API_URL=$(oc get route df-api-route -n $NAMESPACE -o jsonpath='{.spec.host}')
+curl https://$API_URL/health
+```
+
+#### Storage Classes
+
+By default, the chart uses `gp3-csi` storage class for OpenShift. Adjust this in `values.yaml` or via command-line:
+
+```bash
+--set openshift.storageClass="your-storage-class"
+```
+
+### Secret Management
+
+The Data Flywheel chart creates secrets conditionally. When installing on top of existing NeMo Microservices:
+
+**Shared Secrets (created by NeMo):**
+- `nvcrimagepullsecret`: NGC container registry authentication
+- `ngc-api`: NGC API key for model downloads
+- `nvidia-api`: NVIDIA API key for remote inference
+- `hf-secret`: Hugging Face token for datasets
+
+**Data Flywheel-Only Secrets (optional):**
+- `llm-judge-api`: LLM Judge API key (if using separate service)
+- `emb-api`: Embedding API key (if using separate service)
+
+To create Data Flywheel-specific secrets:
+```bash
+# Only if you need separate API keys for LLM Judge or Embeddings
+oc create secret generic llm-judge-api \
+  --from-literal=LLM_JUDGE_API_KEY="<your-key>" \
+  -n $NAMESPACE
+
+oc create secret generic emb-api \
+  --from-literal=EMB_API_KEY="<your-key>" \
+  -n $NAMESPACE
+```
+
+### Resource Configuration
+
+Adjust resources based on your cluster capacity. Example for resource-constrained environments:
+
+```yaml
+# In values-openshift.yaml
+elasticsearch:
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"
+
+mongodb:
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
+foundationalFlywheelServer:
+  deployments:
+    celeryWorker:
+      resources:
+        requests:
+          memory: "4Gi"
+          cpu: "2"
+        limits:
+          memory: "8Gi"
+          cpu: "4"
+```
+
+## Verification
+
+### Check Pod Status
+
+```bash
+# View all Data Flywheel pods
+oc get pods -n $NAMESPACE | grep df-
+
+# Expected output (all Running):
+# df-api-<hash>                  1/1     Running
+# df-celery-worker-<hash>        1/1     Running
+# df-celery-parent-worker-<hash> 1/1     Running
+# df-elasticsearch-<hash>        1/1     Running
+# df-mongodb-<hash>              1/1     Running
+# df-redis-<hash>                1/1     Running
+# df-mlflow-<hash>               1/1     Running (if mlflow enabled)
+# df-flower-<hash>               1/1     Running (if not production)
+# df-kibana-<hash>               1/1     Running (if not production)
+```
+
+### Check Services
+
+```bash
+# View services
+oc get svc -n $NAMESPACE | grep df-
+
+# Expected services:
+# df-api-service
+# df-elasticsearch-service
+# df-mongodb-service
+# df-redis-service
+# df-mlflow-service
+# df-flower-service
+# df-kibana-service
+```
+
+### Check Routes
+
+```bash
+# View routes
+oc get routes -n $NAMESPACE
+
+# Test API health
+API_URL=$(oc get route df-api-route -n $NAMESPACE -o jsonpath='{.spec.host}')
+curl -k https://$API_URL/health
+
+# Expected response:
+# {"status": "healthy"}
+```
+
+### Check Secrets
+
+```bash
+# Verify all required secrets exist
+oc get secrets -n $NAMESPACE | grep -E "(nvcrimagepullsecret|ngc-api|nvidia-api|hf-secret)"
+
+# Expected output:
+# nvcrimagepullsecret   kubernetes.io/dockerconfigjson   1      Xm
+# ngc-api               Opaque                           1      Xm
+# nvidia-api            Opaque                           1      Xm
+# hf-secret             Opaque                           1      Xm
+```
+
+### Verify NeMo Integration
+
+```bash
+# Check if Data Flywheel can reach NeMo gateway
+oc exec -n $NAMESPACE deployment/df-api -- curl -s http://nemo-gateway/health
+
+# Check NeMo datastore
+oc exec -n $NAMESPACE deployment/df-api -- curl -s http://nemodatastore-sample:8000/health
+```
+
+### Access Web Interfaces
+
+```bash
+# Get all route URLs
+echo "Data Flywheel API:    https://$(oc get route df-api-route -n $NAMESPACE -o jsonpath='{.spec.host}')"
+echo "MLflow UI:            https://$(oc get route df-mlflow-route -n $NAMESPACE -o jsonpath='{.spec.host}')"
+echo "Kibana UI:            https://$(oc get route df-kibana-route -n $NAMESPACE -o jsonpath='{.spec.host}')"
+echo "Flower UI:            https://$(oc get route df-flower-route -n $NAMESPACE -o jsonpath='{.spec.host}')"
+```
+
+## Troubleshooting
+
+### Pods in ImagePullBackOff
+
+**Symptom:** Pods fail to pull NVIDIA images from `nvcr.io`
+
+**Solution:**
+```bash
+# Verify NGC secret exists and is correct
+oc get secret nvcrimagepullsecret -n $NAMESPACE -o yaml
+
+# Recreate if needed
+oc delete secret nvcrimagepullsecret -n $NAMESPACE
+oc create secret docker-registry nvcrimagepullsecret \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="$NGC_API_KEY" \
+  -n $NAMESPACE
+```
+
+### Pods in CreateContainerConfigError
+
+**Symptom:** Pods cannot find required secrets
+
+**Solution:**
+```bash
+# Check which secret is missing
+oc describe pod <pod-name> -n $NAMESPACE | grep -A 5 "Secret"
+
+# Verify all required secrets exist
+oc get secrets -n $NAMESPACE | grep -E "(ngc-api|nvidia-api|hf-secret)"
+
+# Create missing secrets (these should have been created by NeMo installation)
+# Refer to the NeMo Microservices installation guide
+```
+
+### SCC Permission Errors
+
+**Symptom:** Pods fail with security context constraint violations
+
+**Solution:**
+```bash
+# Verify openshift.enabled=true was set during installation
+helm get values data-flywheel -n $NAMESPACE | grep "enabled: true"
+
+# If not, upgrade with correct settings
+helm upgrade data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  --set openshift.enabled=true \
+  --reuse-values
+```
+
+### Cannot Connect to NeMo Services
+
+**Symptom:** Data Flywheel cannot reach `nemo-gateway` or other NeMo services
+
+**Solution:**
+```bash
+# Verify NeMo gateway service exists
+oc get svc nemo-gateway -n $NAMESPACE
+
+# If not found, check if NeMo is in a different namespace
+oc get svc --all-namespaces | grep nemo-gateway
+
+# Update the nemo_base_url if in different namespace
+helm upgrade data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  --set foundationalFlywheelServer.config.nmp_config.nemo_base_url="http://nemo-gateway.<nemo-namespace>.svc.cluster.local" \
+  --set foundationalFlywheelServer.config.nmp_config.nmp_namespace="<nemo-namespace>" \
+  --reuse-values
+```
+
+### Elasticsearch Out of Memory
+
+**Symptom:** Elasticsearch pod crashes or is OOMKilled
+
+**Solution:**
+```bash
+# Increase memory limits
+helm upgrade data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  --set elasticsearch.resources.requests.memory="4Gi" \
+  --set elasticsearch.resources.limits.memory="8Gi" \
+  --set elasticsearch.env.ES_JAVA_OPTS="-Xms4g -Xmx4g" \
+  --reuse-values
+```
+
+### Celery Workers Not Processing Tasks
+
+**Symptom:** Tasks stuck in pending state, visible in Flower UI
+
+**Solution:**
+```bash
+# Check worker logs
+oc logs -n $NAMESPACE deployment/df-celery-worker --tail=100
+
+# Check Redis connectivity
+oc exec -n $NAMESPACE deployment/df-celery-worker -- redis-cli -h df-redis-service ping
+
+# Restart workers
+oc rollout restart deployment/df-celery-worker -n $NAMESPACE
+oc rollout restart deployment/df-celery-parent-worker -n $NAMESPACE
+```
+
+### Routes Not Accessible
+
+**Symptom:** Cannot access services via route URLs
+
+**Solution:**
+```bash
+# Verify routes exist
+oc get routes -n $NAMESPACE
+
+# Check route TLS settings
+oc get route df-api-route -n $NAMESPACE -o yaml
+
+# Test internal service first
+oc exec -n $NAMESPACE deployment/df-api -- curl -s http://df-api-service:8000/health
+
+# Check router logs
+oc logs -n openshift-ingress deployment/router-default
+```
+
+### Helm Adoption Errors
+
+**Symptom:** `Secret 'xyz' exists and cannot be imported into the current release`
+
+**Solution:**
+This occurs when secrets exist without Helm ownership labels. The chart has been updated to create secrets conditionally. Ensure you're not passing secret values during installation if they already exist from NeMo:
+
+```bash
+# Don't pass --set secrets.* flags if secrets already exist
+helm install data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  --set openshift.enabled=true \
+  --set namespace=$NAMESPACE \
+  # ... other flags but NO --set secrets.ngcApiKey, etc.
+```
+
+## Advanced Configuration
+
+### Using Custom Storage Classes
+
+```bash
+helm install data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  --set openshift.enabled=true \
+  --set openshift.storageClass="fast-ssd" \
+  # ... other flags
+```
+
+### Disabling Non-Production Services
+
+For production deployments, disable Kibana and Flower:
+
+```bash
+helm install data-flywheel ./deploy/helm/data-flywheel \
+  -n $NAMESPACE \
+  --set profile.production.enabled=true \
+  # ... other flags
+```
+
+This automatically disables:
+- Kibana UI and route
+- Flower UI and route
+
+### Using Local NIMs Instead of Remote API
+
+By default, Data Flywheel uses remote NVIDIA API for LLM judge and embeddings. To use local NIMs:
+
+```yaml
+# In values-openshift.yaml
+foundationalFlywheelServer:
+  config:
+    llm_judge_config:
+      deployment_type: "local"
+      model_name: "meta/llama-3.3-70b-instruct"
+      context_length: 32768
+      gpus: 4
+      pvc_size: 25Gi
+      tag: "1.8.5"
+
+    icl_config:
+      similarity_config:
+        embedding_nim_config:
+          deployment_type: "local"
+          model_name: "nvidia/llama-3.2-nv-embedqa-1b-v2"
+          context_length: 32768
+          gpus: 1
+          pvc_size: "25Gi"
+          tag: "1.9.0"
+```
+
+### Scaling Workers
+
+Adjust Celery worker concurrency based on your workload:
+
+```yaml
+# In values-openshift.yaml
+foundationalFlywheelServer:
+  deployments:
+    celeryWorker:
+      resources:
+        requests:
+          memory: "10Gi"
+          cpu: "4"
+        limits:
+          memory: "20Gi"
+          cpu: "8"
+      command:
+        - "uv"
+        - "run"
+        - "celery"
+        - "-A"
+        - "src.tasks.cli:celery_app"
+        - "worker"
+        - "--loglevel=info"
+        - "--concurrency=100"  # Increase from default 50
+        - "--queues=celery"
+        - "-n"
+        - "main_worker@%h"
+        - "--purge"
+```
+
+## References
+
+- [NeMo Microservices on OpenShift](https://github.com/RHEcosystemAppEng/NeMo-Microservices) - Complete OpenShift installation guide for NeMo
+- [Data Flywheel Blueprint Documentation](https://github.com/NVIDIA-AI-Blueprints/nvidia-data-flywheel/tree/main/docs)
+- [NVIDIA NeMo Microservices Documentation](https://docs.nvidia.com/nemo/microservices/latest/index.html)
+- [OpenShift Security Context Constraints](https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html)
+- [OpenShift Routes](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html)
+
+## Support
+
+For issues specific to:
+- **OpenShift deployment**: Create an issue in this repository
+- **NeMo Microservices on OpenShift**: Refer to [NeMo Microservices on OpenShift repo](https://github.com/RHEcosystemAppEng/NeMo-Microservices)
+- **Data Flywheel functionality**: Create an issue in the [main Data Flywheel repository](https://github.com/NVIDIA-AI-Blueprints/data-flywheel)


### PR DESCRIPTION
**Summary**
This PR adds full OpenShift deployment support to the Data Flywheel Helm chart, enabling deployment on OpenShift clusters with the restricted-v2 Security Context Constraints (SCC). The implementation is controlled by a feature flag and maintains backward compatibility with standard Kubernetes deployments.

**Changes Overview**
1. OpenShift Configuration Framework ([values.yaml](deploy/helm/data-flywheel/values.yaml))
Added openshift.enabled flag to toggle OpenShift-specific features
Implemented security context configurations compliant with OpenShift restricted-v2 SCC:
Pod-level: runAsNonRoot, seccompProfile (RuntimeDefault)
Container-level: allowPrivilegeEscalation: false, drop all capabilities
Added OpenShift Route configuration for external access (API, MLflow, Kibana, Flower) with TLS support
Configurable storage class override (gp3-csi default)
UBI-based init container image for OpenShift compatibility
2. Helm Template Helpers ([_helpers.tpl](deploy/helm/data-flywheel/templates/_helpers.tpl))
data-flywheel.podSecurityContext: Generates OpenShift-compliant pod security context
data-flywheel.containerSecurityContext: Generates OpenShift-compliant container security context
data-flywheel.serviceType: Dynamically selects service type (ClusterIP for OpenShift, NodePort for K8s)
3. OpenShift Routes (New files)
[api-route.yaml](deploy/helm/data-flywheel/templates/api-route.yaml)
[mlflow-route.yaml](deploy/helm/data-flywheel/templates/mlflow-route.yaml)
[kibana-route.yaml](deploy/helm/data-flywheel/templates/kibana-route.yaml)
[flower-route.yaml](deploy/helm/data-flywheel/templates/flower-route.yaml)
All routes support:
Auto-generated or custom hostnames
Edge TLS termination
HTTP to HTTPS redirection
Conditional deployment based on profile settings
4. Deployment Updates (All deployment templates updated)
Modified all deployments (API, Celery workers, MongoDB, Redis, Elasticsearch, MLflow, Kibana, Flower) to include:
Conditional security contexts when openshift.enabled: true
Init containers for volume preparation using UBI minimal images
Persistent volume mounts with emptyDir volumes for stateful services (MongoDB, Redis)
Service type switching (ClusterIP vs NodePort)
5. Secret Management Enhancement ([secrets.yaml](deploy/helm/data-flywheel/templates/secrets.yaml))
Fixed secret creation to only generate secrets when values are provided
Prevents empty secret creation that could cause deployment issues
Improves security posture by avoiding placeholder credentials


**Technical Details**

1. Security Context Strategy:
Complies with OpenShift's restricted-v2 SCC without requiring cluster-admin privileges
Allows dynamic UID/GID assignment by OpenShift
Drops all container capabilities and disables privilege escalation
Uses RuntimeDefault seccomp profile
2. Init Container Pattern:
Uses Red Hat UBI minimal image (registry.access.redhat.com/ubi8/ubi-minimal) for OpenShift
Falls back to busybox for standard Kubernetes
Prepares volumes for MongoDB and Redis without requiring root permissions
3. Testing Recommendations
- Test deployment with openshift.enabled: false to verify backward compatibility
- Test deployment with openshift.enabled: true on OpenShift cluster with restricted SCC
- Verify all routes are accessible with TLS enabled
- Confirm all services start successfully with proper volume permissions

**Breaking Changes**
None - all changes are backward compatible and gated behind the openshift.enabled flag.